### PR TITLE
Update for Blazor 0.9

### DIFF
--- a/AspNetMonsters.Blazor.Geolocation/AspNetMonsters.Blazor.Geolocation.csproj
+++ b/AspNetMonsters.Blazor.Geolocation/AspNetMonsters.Blazor.Geolocation.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.7.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.9.0-preview3-19154-02" />
   </ItemGroup>
 
 </Project>

--- a/AspNetMonsters.Blazor.Geolocation/AspNetMonsters.Blazor.Geolocation.csproj
+++ b/AspNetMonsters.Blazor.Geolocation/AspNetMonsters.Blazor.Geolocation.csproj
@@ -11,7 +11,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyName>AspNetMonsters.Blazor.Geolocation</AssemblyName>
     <RootNamespace>AspNetMonsters.Blazor.Geolocation</RootNamespace>
-    <Version>0.4.0.1017</Version>
+    <Version>0.4.0.1018-PRE</Version>
 
     <DefaultItemExcludes>${DefaultItemExcludes};node_modules\**</DefaultItemExcludes>
   </PropertyGroup>
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.7.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="0.9.0-preview3-19154-02" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.9.0-preview3-19154-02" />
   </ItemGroup>
 

--- a/AspNetMonsters.Blazor.Geolocation/LocationService.cs
+++ b/AspNetMonsters.Blazor.Geolocation/LocationService.cs
@@ -10,6 +10,12 @@ namespace AspNetMonsters.Blazor.Geolocation
     {
         static IDictionary<Guid, TaskCompletionSource<Location>> _pendingRequests = new Dictionary<Guid, TaskCompletionSource<Location>>();
         static IDictionary<Guid, Action<Location>> _watches = new Dictionary<Guid, Action<Location>>();
+        private readonly IJSRuntime jSRuntime;
+
+        public LocationService(IJSRuntime jSRuntime)
+        {
+            this.jSRuntime = jSRuntime;
+        }
 
         public async Task<Location> GetLocationAsync()
         {
@@ -17,7 +23,7 @@ namespace AspNetMonsters.Blazor.Geolocation
             var requestId = Guid.NewGuid();
 
             _pendingRequests.Add(requestId, tcs);
-            var result = await JSRuntime.Current.InvokeAsync<Location>("AspNetMonsters.Blazor.Geolocation.GetLocation", requestId);
+            var result = await jSRuntime.InvokeAsync<Location>("AspNetMonsters.Blazor.Geolocation.GetLocation", requestId);
             
             return await tcs.Task;
         }
@@ -26,7 +32,7 @@ namespace AspNetMonsters.Blazor.Geolocation
         {
             var requestId = Guid.NewGuid();
             _watches.Add(requestId, watchCallback);
-            await JSRuntime.Current.InvokeAsync<Location>("AspNetMonsters.Blazor.Geolocation.WatchLocation", requestId);
+            await jSRuntime.InvokeAsync<Location>("AspNetMonsters.Blazor.Geolocation.WatchLocation", requestId);
         }
 
         [JSInvokable]


### PR DESCRIPTION
Made the updates necessary to use this package with Blazor 0.9.

- Updated the package references.
- Use dependency injection for use of IJSRuntime (replaces calls to static JSRuntime.Current).